### PR TITLE
fix: pinceau dependency error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@nuxtjs/color-mode": "^3.3.0",
     "@vueuse/core": "^10.3.0",
-    "pinceau": "^0.20.1"
+    "pinceau": "0.15.4"
   },
   "devDependencies": {
     "style-value-types": "^5.1.2",


### PR DESCRIPTION
Current issue.
With greater version then 0.15.4

on nuxt docus npm run build command fails due this issue

Issue Link: https://github.com/nuxt-themes/docus/issues/986